### PR TITLE
Adds Container Image Publishing

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,19 +5,43 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch: {}
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    permissions:
+      packages: write
+      contents: read
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+      PUBLISH: ${{ github.ref == 'refs/heads/master' }}
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET 7
-      uses: actions/setup-dotnet@v1
+    - uses: docker/setup-buildx-action@v2
+      id: buildx
       with:
-        dotnet-version: 7.0.100-rc.1.22431.12
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
+        install: true
+        version: latest
+    - uses: docker/login-action@v2
+      if: ${{ env.PUBLISH }}
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.IMAGE_NAME }}
+        tags: |
+          type=sha
+          type=edge
+          type=raw,value=latest,enable={{is_default_branch}}
+    - uses: docker/build-push-action@v3
+      id: build
+      with:
+        file: Dockerfile
+        context: .
+        push: ${{ env.PUBLISH }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,8 @@ RUN dotnet publish -c release -o /app
 FROM mcr.microsoft.com/dotnet/aspnet:7.0
 WORKDIR /app
 COPY --from=build /app ./
+
+LABEL org.opencontainers.image.source=https://github.com/tobyash86/WebGoat.NET
+LABEL org.opencontainers.image.description="WebGoat.NETCore - port of original WebGoat.NET to .NET Core"
+
 ENTRYPOINT ["dotnet", "WebGoat.NET.dll"] 


### PR DESCRIPTION
This pr adds container image publishing to `ghcr.io` on commits to trunk.

Example run: https://github.com/Contrast-Security-OSS/WebGoat.NET/actions/runs/3283632870/jobs/5408596085
Example image: https://github.com/Contrast-Security-OSS/WebGoat.NET/pkgs/container/webgoat.net

This pr also removes building the app directly in the pipeline, in favor of the Dockerfile building all (only have to update the .NET SDK version once). Finally, this pr adds the trigger `workflow_dispatch` to allow running the pipeline without needing to push (just what I add to all pipelines).

It might be useful to add dependabot DockerFile updates e.g. https://github.com/Contrast-Security-OSS/agent-operator/blob/master/.github/dependabot.yml